### PR TITLE
Wrap NumberFormatException for port number parsing

### DIFF
--- a/core/common/io/src/main/java/org/eclipse/rdf4j/common/net/ParsedIRI.java
+++ b/core/common/io/src/main/java/org/eclipse/rdf4j/common/net/ParsedIRI.java
@@ -783,7 +783,11 @@ public class ParsedIRI implements Cloneable, Serializable {
 				advance(1);
 				String p = parseMember(DIGIT, '/');
 				if (p.length() > 0) {
-					port = Integer.parseInt(p);
+                                        try {
+        					port = Integer.parseInt(p);
+                                        } catch (NumberFormatException e) {
+                                                throw new URISyntaxException("Port number is invalid.");
+                                        }
 				} else {
 					port = -1;
 				}


### PR DESCRIPTION
This fixes a possible unwrapped NumberFormatException in core/common/io/src/main/java/org/eclipse/rdf4j/common/net/ParsedIRI.java.


In [Line 786](https://github.com/eclipse/rdf4j/blob/main/core/common/io/src/main/java/org/eclipse/rdf4j/common/net/ParsedIRI.java#L786) of the PArsedIRI class. The string representing the port number of the URI is being passed to the `Integer.parseInt(String)` method. If the provided port number is malformed or too large, it will result in a NumberFormatException and be directly thrown to the user because it is not handled, wrapped or captured. 


This PR adds an additional try catch block to capture and wrap the NumberFormatException with the URISyntaxException which is explicitly thrown by the method when the URI is invalid.


We found this bug using fuzzing by way of OSS-Fuzz, where we recently integrated rdf4j (https://github.com/google/oss-fuzz/pull/10683). OSS-Fuzz is a free service run by Google for fuzzing important open source software. If you'd like to know more about this then I'm happy to go into detail and also set up things so you can receive emails and detailed reports when bugs are found.
